### PR TITLE
Update the helper library, documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,30 +4,42 @@ Front end for the various MS test apps.
 
 ## How to integrate a test app
 
-There are three intent actions that should be caught:
-- `<your package name>.action.TRIAL`
-- `<your package name>.action.PRACTICE`
-- `<your package name>.action.HELP`
+There are three intent actions (in the category `android.intent.category.DEFAULT`) that should be caught by the test app's intent-filters:
+- `edu.umd.cmsc436.{...}.action.TRIAL`
+- `edu.umd.cmsc436.{...}.action.PRACTICE`
+- `edu.umd.cmsc436.{...}.action.HELP`
 
-For example, if MS Test Suite reacted to Practice Mode, it would catch intents with the `edu.umd.cmsc436.mstestsuite.action.PRACTICE` action.  This way, a specific test and mode can be simulateously specified.
+The possible values in the curly braces are:
+- `tap`
+- `spiral`
+- `balance`
+- `level`
+- `pop`
+- `flex`
+- `walk.outdoors`
+- `walk.indoors`
+
+For example, the intent to launch the Practice Mode of the Tap app would have the action `edu.umd.cmsc436.tap.action.PRACTICE`.
 
 `.PRACTICE` and `.HELP` don't have any arguments or expect any results.
 
-`.TRIAL` has 4 arguments:
+`.TRIAL` has 5 arguments:
 - Appendage, which is a `Sheets.TestType` (from the [sheets436](https://github.com/cmsc436/sheets436) library)
 - Trial Num, an integer, the current trial out of this appendage's number of trials, for display purposes
 - Trial Out Of, an integer, the current appendage's number of trials, for display purposes
 - Patient ID, a string, for storing raw data appropriately
-
-`.TRIAL` also expects a single float result, the score for the trial.  This can be done with the [`Activity#setResult(int, Intent)`](https://developer.android.com/reference/android/app/Activity.html#setResult(int%2c%20android.content.Intent)) method, and the intent from the `TrialMode.getResultIntent(float)` helper static method.
+- Difficulty, an integer greater than 0, the lower the easier
 
 There are a few static methods to help with argument extraction as well:
 - `getAppendage(Intent)`
 - `getTrialNum(Intent)`
 - `getTrialOutOf(Intent)`
 - `getPatientId(Intent)`
+- `getDifficulty(Intent)`
 
 These will help with getting info out of intents delivered with the `.TRIAL` action.
+
+`.TRIAL` also expects a single float result, the score for the trial.  This can be done with the [`Activity#setResult(int, Intent)`](https://developer.android.com/reference/android/app/Activity.html#setResult(int%2c%20android.content.Intent)) method, and the intent from the `TrialMode.getResultIntent(float)` helper static method.
 
 The helper library uses types from the sheets436 library, so make sure to include that as a dependency.  There are also a few color resources defined to help with consistency:
 - `colorPrimary436`, orange
@@ -36,7 +48,7 @@ The helper library uses types from the sheets436 library, so make sure to includ
 - `colorAccentLight436`, a light blue
 - `colorBackground436`, a light gray
 
-These value were taken from [colorcombos.com](http://www.colorcombos.com/color-schemes/89/ColorCombo89.html).
+These values were taken from [colorcombos.com](http://www.colorcombos.com/color-schemes/89/ColorCombo89.html).
 
 ## Prescription Format
 

--- a/app/src/main/java/edu/umd/cmsc436/mstestsuite/MainPresenter.java
+++ b/app/src/main/java/edu/umd/cmsc436/mstestsuite/MainPresenter.java
@@ -78,7 +78,7 @@ class MainPresenter implements MainContract.Presenter, TestApp.Events {
 
     private TestApp[] loadAppInfo() {
         Resources res = mView.getContext().getResources();
-        TypedArray package_names = res.obtainTypedArray(R.array.package_names);
+        TypedArray package_names = res.obtainTypedArray(R.array.test_prefixes);
         TypedArray display_names = res.obtainTypedArray(R.array.display_names);
         TypedArray icons = res.obtainTypedArray(R.array.icons);
 

--- a/app/src/main/res/values/tests.xml
+++ b/app/src/main/res/values/tests.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <array name="package_names">
-        <item>"edu.umd.cmsc436.mstestsuite"</item>
-        <item>"cmsc436.mstracer"</item>
-        <item>"edu.umd.cmsc436.mstestsuite"</item>
-        <item>"edu.umd.cmsc436.mstestsuite"</item>
-        <item>"edu.umd.cmsc436.mstestsuite"</item>
-        <item>"edu.umd.cmsc436.mstestsuite"</item>
-        <item>"edu.umd.cmsc436.mstestsuite"</item>
-        <item>"edu.umd.cmsc436.mstestsuite"</item>
+    <array name="test_prefixes">
+        <item>"edu.umd.cmsc436.tap"</item>
+        <item>"edu.umd.cmsc436.spiral"</item>
+        <item>"edu.umd.cmsc436.balance"</item>
+        <item>"edu.umd.cmsc436.level"</item>
+        <item>"edu.umd.cmsc436.pop"</item>
+        <item>"edu.umd.cmsc436.flex"</item>
+        <item>"edu.umd.cmsc436.walk.outdoors"</item>
+        <item>"edu.umd.cmsc436.walk.indoors"</item>
     </array>
 
     <array name="display_names">

--- a/frontendhelper/src/main/java/edu/umd/cmsc436/frontendhelper/TrialMode.java
+++ b/frontendhelper/src/main/java/edu/umd/cmsc436/frontendhelper/TrialMode.java
@@ -16,6 +16,7 @@ public class TrialMode {
     public static final String KEY_TRIAL_OUT_OF = "trial out of";
     public static final String KEY_PATIENT_ID = "patient id";
     public static final String KEY_SCORE = "score";
+    public static final String KEY_DIFFICULTY = "difficulty";
 
     /**
      * Extract the Test Type from the intent
@@ -67,6 +68,15 @@ public class TrialMode {
     @Nullable
     public static String getPatientId (Intent i) {
         return i.getStringExtra(KEY_PATIENT_ID);
+    }
+
+    /**
+     * Gets the difficulty for this trial fromt he frontend intent
+     * @param i intent from the frontend, with .TRIAL action
+     * @return the difficulty, greater than 0 or -1 if not found
+     */
+    public static int getDifficulty (Intent i) {
+        return i.getIntExtra(KEY_DIFFICULTY, -1);
     }
 
     /**


### PR DESCRIPTION
New strategy for the various actions: generic names not tied to the package names of the test apps.  Helper library can now extract the difficulty argument.